### PR TITLE
update the name-kv-16 variable

### DIFF
--- a/secret.tf
+++ b/secret.tf
@@ -3,8 +3,9 @@ locals {
   group_4                   = substr(var.group, 0, 4)
   project_4                 = substr(var.project, 0, 4)
   userDefinedString-replace = replace("${local.group_4}-${local.project_4}", "_", "-")
+  userDefinedString-clean   = substr(local.userDefinedString-replace, -1, 1) == "-" ? trimsuffix(local.userDefinedString-replace, "-") : local.userDefinedString-replace
   kv_sha                    = substr(sha1(var.resource_groups["Keyvault"].id), 0, 8)
-  name-kv-16                = substr("${local.env_4}CKV-${local.userDefinedString-replace}", 0, 16)
+  name-kv-16                = substr("${local.env_4}CKV-${local.userDefinedString-clean}", 0, 16)
   name-kv-21                = substr("${local.name-kv-16}-${local.kv_sha}", 0, 21)
   kv_name                   = replace("${local.name-kv-21}-kv", local.name-regex, "")
   kv_resource_group_name    = try(var.vmss.key_vault.resource_group_name, "Keyvault")


### PR DESCRIPTION
added code to check and trim an extra dash in CKV variable. if the 17th character is a dash it remove it so there is not a double dash.   Example,  GCDc-XXX_GOV-Pro--XXXX-KV   -> becomes  -> GCDc-XXX_GOV-Pro-XXXX-KV so it can located the key vault